### PR TITLE
docs: Fix "an user" typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Dispatching an `async action` cannot change the state but it can dispatch `actio
 
 ## How does one use this thing?
 
-Here is a short example of Reducto in action. Let's write an app that authenticates an user. 
+Here is a short example of Reducto in action. Let's write an app that authenticates a user. 
 
 First, let's define the `actions` that we will need:
 


### PR DESCRIPTION
In english, the word "an" goes before words that begin with a vowel sound. Exceptions are expressions like "a user", "a unicorn" or "a union". Although they begin with the vowel "u", it has a consonant sound. It is also possible to have a consonant as the first letter and still use "an" instead of "a". For example: "an hour".